### PR TITLE
Add option to view feed without loading feeds from a config

### DIFF
--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -13,17 +13,23 @@ import (
 )
 
 type Options struct {
-	Verbose    bool   `short:"v" long:"verbose" description:"Show verbose logging"`
-	Number     int    `short:"n" long:"number" description:"Number of results to show"`
-	Pager      string `short:"p" long:"pager" description:"Pager to use for longer output. Set to false for no pager"`
-	NoCache    bool   `long:"no-cache" description:"Do not use the cache"`
-	ConfigPath string `long:"config-path" description:"Location of config.yml"`
+	Verbose      bool     `short:"v" long:"verbose" description:"Show verbose logging"`
+	Number       int      `short:"n" long:"number" description:"Number of results to show"`
+	Pager        string   `short:"p" long:"pager" description:"Pager to use for longer output. Set to false for no pager"`
+	NoCache      bool     `long:"no-cache" description:"Do not use the cache"`
+	ConfigPath   string   `long:"config-path" description:"Location of config.yml"`
+	PreviewFeeds []string `short:"f" long:"feed" description:"Feed(s) URL(s) for preview"`
 }
 
 var ErrNotEnoughArgs = errors.New("not enough args")
 
 func run(args []string, opts Options) error {
-	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache)
+	if len(opts.PreviewFeeds) > 0 {
+		// Don't mess up the cache of configured feeds in the preview mode.
+		opts.NoCache = true
+	}
+
+	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache, opts.PreviewFeeds)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/main.go
+++ b/internal/commands/main.go
@@ -95,7 +95,7 @@ func (c Commands) fetchAllFeeds(noCacheOverride bool) ([]rss.RSS, error) {
 		wg   sync.WaitGroup
 	)
 
-	feeds := c.config.Feeds
+	feeds := c.config.GetFeeds()
 
 	if len(feeds) <= 0 {
 		return []rss.RSS{}, fmt.Errorf("no feeds found, add to nom/config.yml")

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -14,26 +14,43 @@ const configFixturePath = "../test/data/config_fixture.yml"
 const configFixtureWritePath = "../test/data/config_fixture_write.yml"
 
 func TestNewDefault(t *testing.T) {
-	c, _ := New("", "", false)
+	c, _ := New("", "", false, []string{})
 	ucd, _ := os.UserConfigDir()
 
 	test.Equal(t, fmt.Sprintf("%s/nom/config.yml", ucd), c.configPath, "Wrong defaults set")
 }
 
 func TestConfigCustomPath(t *testing.T) {
-	c, _ := New("foo/bar.yml", "", false)
+	c, _ := New("foo/bar.yml", "", false, []string{})
 
 	test.Equal(t, "foo/bar.yml", c.configPath, "Config path override not set")
 }
 
 func TestNewOverride(t *testing.T) {
-	c, _ := New("foobar", "", false)
+	c, _ := New("foobar", "", false, []string{})
 
 	test.Equal(t, "foobar", c.configPath, "Override not respected")
 }
 
+func TestPreviewFeedsOverrideFeedsFromConfigFile(t *testing.T) {
+	c, _ := New(configFixturePath, "", false, []string{})
+	c.Load()
+	feeds := c.GetFeeds()
+	test.Equal(t, 3, len(feeds), "Incorrect feeds number")
+	test.Equal(t, "cattle", feeds[0].URL, "First feed in a config must be cattle")
+	test.Equal(t, "bird", feeds[1].URL, "First feed in a config must be bird")
+	test.Equal(t, "dog", feeds[2].URL, "Third feed in a config must be dog")
+
+	c, _ = New(configFixturePath, "", false, []string{"pumpkin", "raddish"})
+	c.Load()
+	feeds = c.GetFeeds()
+	test.Equal(t, 2, len(feeds), "Incorrect feeds number")
+	test.Equal(t, "pumpkin", feeds[0].URL, "First feed in a config must be pumpkin")
+	test.Equal(t, "raddish", feeds[1].URL, "First feed in a config must be raddish")
+}
+
 func TestConfigLoad(t *testing.T) {
-	c, _ := New(configFixturePath, "", false)
+	c, _ := New(configFixturePath, "", false, []string{})
 	err := c.Load()
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -45,7 +62,7 @@ func TestConfigLoad(t *testing.T) {
 }
 
 func TestConfigLoadPrecidence(t *testing.T) {
-	c, _ := New(configFixturePath, "testpager", false)
+	c, _ := New(configFixturePath, "testpager", false, []string{})
 
 	err := c.Load()
 	if err != nil {
@@ -58,7 +75,7 @@ func TestConfigLoadPrecidence(t *testing.T) {
 }
 
 func TestConfigAddFeed(t *testing.T) {
-	c, _ := New(configFixtureWritePath, "", false)
+	c, _ := New(configFixtureWritePath, "", false, []string{})
 
 	err := c.Load()
 	if err != nil {


### PR DESCRIPTION
Hey there!

This deals with issue #13 

The proposed solution is to add a `--preview` flag, but I find it unnecessary as

```
nom <URL>
```

feels like a more straightforward interface since we can check if `args[0]` is a URL or not and as such distinguish vs commands

idk if it's a good solution, I have 0 experience with go and 0 experience contributing to open source projects. But I was looking forward to make my first one not only to learn go, but contribute to something that I actually looking to use (long time newsboat user) and a feature to preview a feed looked like a nice opportunity as it was something I was missing in newsboat.

The solution doesn't use cache, and as such a little slow on transitions, - maybe a short-lived in-memory cache can be implemented here. 

Code review is very much appreciated!

Cheers.

Demo



https://user-images.githubusercontent.com/795034/213139202-b3aa7be3-890e-414c-896e-121bed46efdd.mov


