### PR TITLE
short lived cache

### DIFF
--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -18,12 +19,22 @@ type Options struct {
 	Pager      string `short:"p" long:"pager" description:"Pager to use for longer output. Set to false for no pager"`
 	NoCache    bool   `long:"no-cache" description:"Do not use the cache"`
 	ConfigPath string `long:"config-path" description:"Location of config.yml"`
+	Preview    string
 }
 
 var ErrNotEnoughArgs = errors.New("not enough args")
 
 func run(args []string, opts Options) error {
-	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache)
+	preview := ""
+	if len(args) > 0 {
+		_, err := url.ParseRequestURI(args[0])
+		if err == nil {
+			// args[0] is a valid url
+			preview = args[0]
+			args = args[1:]
+		}
+	}
+	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache, preview)
 	if err != nil {
 		return err
 	}

--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -25,18 +24,7 @@ type Options struct {
 var ErrNotEnoughArgs = errors.New("not enough args")
 
 func run(args []string, opts Options) error {
-	var previewFeeds []string
-	for i := len(args) - 1; i >= 0; i-- {
-		_, err := url.ParseRequestURI(args[i])
-		if err == nil {
-			previewFeeds = append(previewFeeds, args[i])
-			args = append(args[:i], args[i+1:]...)
-		}
-	}
 	if len(opts.PreviewFeeds) > 0 {
-		previewFeeds = append(previewFeeds, opts.PreviewFeeds...)
-	}
-	if len(previewFeeds) > 0 {
 		// Don't mess up the cache of configured feeds in the preview mode.
 		// Preview mode should use short-lived in-momory cache, but to make it
 		// happen we should support that through a cache interface.
@@ -45,7 +33,7 @@ func run(args []string, opts Options) error {
 		opts.NoCache = true
 	}
 
-	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache, previewFeeds)
+	cfg, err := config.New(opts.ConfigPath, opts.Pager, opts.NoCache, opts.PreviewFeeds)
 	if err != nil {
 		return err
 	}

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -1,0 +1,109 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/guyfedwards/nom/internal/rss"
+)
+
+var DefaultPath = filepath.Join(os.TempDir(), "nom")
+
+type FileCache struct {
+	expiry  time.Duration
+	path    string
+	content CacheContent
+}
+
+// Write writes content to a file at the location specified in the cache
+func (c *FileCache) Write(key string, content rss.RSS) error {
+	err := createCacheIfNotExists(c.path)
+	if err != nil {
+		return fmt.Errorf("createcache: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(c.path, "cache.json"))
+	if err != nil {
+		return fmt.Errorf("cache Write: %w", err)
+	}
+
+	var cc CacheContent
+
+	err = json.Unmarshal(data, &cc)
+	if err != nil {
+		return fmt.Errorf("cache Write json unmarshal: %w", err)
+	}
+
+	cc[key] = content
+
+	str, err := json.Marshal(cc)
+	if err != nil {
+		return fmt.Errorf("cache write marshal json: %w", err)
+	}
+
+	err = os.WriteFile(filepath.Join(c.path, "cache.json"), str, 0655)
+	if err != nil {
+		return fmt.Errorf("cache Write: %w", err)
+	}
+
+	return nil
+}
+
+// Read reads from the cache, returning a ErrFileCacheMiss if nothing found or
+// if the cache is older than the expiry
+func (c *FileCache) Read(key string) (rss.RSS, error) {
+	err := createCacheIfNotExists(c.path)
+	if err != nil {
+		return rss.RSS{}, fmt.Errorf("cache read: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(c.path, "cache.json"))
+	if err != nil {
+		return rss.RSS{}, fmt.Errorf("cache read file: %w", err)
+	}
+
+	var cc CacheContent
+
+	err = json.Unmarshal(data, &cc)
+	if err != nil {
+		return rss.RSS{}, fmt.Errorf("cache read unmarshal: %w", err)
+	}
+
+	if _, ok := cc[key]; !ok {
+		return rss.RSS{}, ErrCacheMiss
+	}
+
+	return cc[key], nil
+}
+
+func createCacheIfNotExists(path string) error {
+	cachePath := filepath.Join(path, "cache.json")
+	info, _ := os.Stat(cachePath)
+	if info != nil {
+		return nil
+	}
+
+	fmt.Println("No existing cache found, creating")
+
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return fmt.Errorf("createDirIfNotExists: %w", err)
+	}
+
+	var cc = make(CacheContent)
+
+	str, err := json.Marshal(cc)
+	if err != nil {
+		return fmt.Errorf("createDirIfNotExists: %w", err)
+	}
+
+	err = os.WriteFile(cachePath, []byte(str), 0655)
+	if err != nil {
+		return fmt.Errorf("createDirIfNotExists: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cache/main.go
+++ b/internal/cache/main.go
@@ -1,11 +1,7 @@
 package cache
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/guyfedwards/nom/internal/rss"
@@ -13,6 +9,11 @@ import (
 
 // key is feedurl
 type CacheContent = map[string]rss.RSS
+
+type CacheInterface interface {
+	Write(key string, content rss.RSS) error
+	Read(key string) (rss.RSS, error)
+}
 
 type Cache struct {
 	expiry  time.Duration
@@ -26,102 +27,13 @@ var ErrCacheMiss = errors.New("cache miss")
 // 24hrs
 const DefaultExpiry time.Duration = 24 * 60 * 60 * 1000 * 1000 * 1000
 
-var DefaultPath = filepath.Join(os.TempDir(), "nom")
-
-// creates a new cache
-func New(path string, expiry time.Duration) Cache {
-	return Cache{
+func NewFileCache(path string, expiry time.Duration) CacheInterface {
+	return &FileCache{
 		expiry: expiry,
 		path:   path,
 	}
 }
 
-// Write writes content to a file at the location specified in the cache
-func (c *Cache) Write(key string, content rss.RSS) error {
-	err := createCacheIfNotExists(c.path)
-	if err != nil {
-		return fmt.Errorf("createcache: %w", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(c.path, "cache.json"))
-	if err != nil {
-		return fmt.Errorf("cache Write: %w", err)
-	}
-
-	var cc CacheContent
-
-	err = json.Unmarshal(data, &cc)
-	if err != nil {
-		return fmt.Errorf("cache Write json unmarshal: %w", err)
-	}
-
-	cc[key] = content
-
-	str, err := json.Marshal(cc)
-	if err != nil {
-		return fmt.Errorf("cache write marshal json: %w", err)
-	}
-
-	err = os.WriteFile(filepath.Join(c.path, "cache.json"), str, 0655)
-	if err != nil {
-		return fmt.Errorf("cache Write: %w", err)
-	}
-
-	return nil
-}
-
-// Read reads from the cache, returning a ErrCacheMiss if nothing found or
-// if the cache is older than the expiry
-func (c *Cache) Read(key string) (rss.RSS, error) {
-	err := createCacheIfNotExists(c.path)
-	if err != nil {
-		return rss.RSS{}, fmt.Errorf("cache read: %w", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(c.path, "cache.json"))
-	if err != nil {
-		return rss.RSS{}, fmt.Errorf("cache read file: %w", err)
-	}
-
-	var cc CacheContent
-
-	err = json.Unmarshal(data, &cc)
-	if err != nil {
-		return rss.RSS{}, fmt.Errorf("cache read unmarshal: %w", err)
-	}
-
-	if _, ok := cc[key]; !ok {
-		return rss.RSS{}, ErrCacheMiss
-	}
-
-	return cc[key], nil
-}
-
-func createCacheIfNotExists(path string) error {
-	cachePath := filepath.Join(path, "cache.json")
-	info, _ := os.Stat(cachePath)
-	if info != nil {
-		return nil
-	}
-
-	fmt.Println("No existing cache found, creating")
-
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		return fmt.Errorf("createDirIfNotExists: %w", err)
-	}
-
-	var cc = make(CacheContent)
-
-	str, err := json.Marshal(cc)
-	if err != nil {
-		return fmt.Errorf("createDirIfNotExists: %w", err)
-	}
-
-	err = os.WriteFile(cachePath, []byte(str), 0655)
-	if err != nil {
-		return fmt.Errorf("createDirIfNotExists: %w", err)
-	}
-
-	return nil
+func NewMemoryCache() CacheInterface {
+	return &MemoryCache{}
 }

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -1,0 +1,26 @@
+package cache
+
+import "github.com/guyfedwards/nom/internal/rss"
+
+type MemoryCache struct {
+	content CacheContent
+}
+
+// Write writes content to a file at the location specified in the cache
+func (c *MemoryCache) Write(key string, content rss.RSS) error {
+	if c.content == nil {
+		c.content = make(CacheContent)
+	}
+	c.content[key] = content
+	return nil
+}
+
+// Read reads from the cache, returning a ErrFileCacheMiss if nothing found or
+// if the cache is older than the expiry
+func (c *MemoryCache) Read(key string) (rss.RSS, error) {
+	if _, ok := c.content[key]; !ok {
+		return rss.RSS{}, ErrCacheMiss
+	}
+
+	return c.content[key], nil
+}

--- a/internal/commands/main.go
+++ b/internal/commands/main.go
@@ -1,11 +1,11 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -90,19 +90,12 @@ type FetchResultError struct {
 }
 
 func (c Commands) fetchAllFeeds(noCacheOverride bool) ([]rss.RSS, error) {
-
 	var (
 		rsss []rss.RSS
 		wg   sync.WaitGroup
 	)
 
-	if c.config.Preview != "" {
-		feed, err := rss.Fetch(c.config.Preview)
-		rsss = append(rsss, feed)
-		return rsss, err
-	}
-
-	feeds := c.config.Feeds
+	feeds := c.config.GetFeeds()
 
 	if len(feeds) <= 0 {
 		return []rss.RSS{}, fmt.Errorf("no feeds found, add to nom/config.yml")
@@ -169,14 +162,22 @@ func (c Commands) FindArticle(substr string) (item rss.Item, err error) {
 		return rss.Item{}, fmt.Errorf("commands.FindArticle: %w", err)
 	}
 
+	regex, err := regexp.Compile(strings.ToLower(substr))
+	if err != nil {
+		return rss.Item{}, fmt.Errorf("commands.FindArticle: regexp: %w", err)
+	}
+
 	for _, r := range rsss {
-		item, err := r.FindArticle(substr)
-		if item != nil || err != nil {
-			return *item, err
+		for _, it := range r.Channel.Items {
+			// very basic string matching on title to read an article
+			if regex.MatchString(strings.ToLower(it.Title)) {
+				item = it
+				break
+			}
 		}
 	}
 
-	return rss.Item{}, errors.New(fmt.Sprintf("Article %s not found", substr))
+	return item, nil
 }
 
 func (c Commands) FindGlamourisedArticle(substr string) (string, error) {

--- a/internal/commands/main.go
+++ b/internal/commands/main.go
@@ -18,10 +18,10 @@ import (
 
 type Commands struct {
 	config config.Config
-	cache  cache.Cache
+	cache  cache.CacheInterface
 }
 
-func New(config config.Config, cache cache.Cache) Commands {
+func New(config config.Config, cache cache.CacheInterface) Commands {
 	return Commands{config, cache}
 }
 

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -19,9 +19,10 @@ type Config struct {
 	Pager      string `yaml:"pager,omitempty"`
 	NoCache    bool   `yaml:"no-cache,omitempty"`
 	Feeds      []Feed `yaml:"feeds"`
+	Preview    string `yaml:"preview,omitempty"`
 }
 
-func New(configPath string, pager string, noCache bool) (Config, error) {
+func New(configPath string, pager string, noCache bool, preview string) (Config, error) {
 	if configPath == "" {
 		userConfigDir, err := os.UserConfigDir()
 		if err != nil {
@@ -36,6 +37,7 @@ func New(configPath string, pager string, noCache bool) (Config, error) {
 		Pager:      pager,
 		NoCache:    noCache,
 		Feeds:      []Feed{},
+		Preview:    preview,
 	}, nil
 }
 

--- a/internal/rss/main.go
+++ b/internal/rss/main.go
@@ -3,6 +3,8 @@ package rss
 import (
 	"fmt"
 	"log"
+	"regexp"
+	"strings"
 	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
@@ -29,6 +31,19 @@ type Channel struct {
 
 type RSS struct {
 	Channel Channel `xml:"channel"`
+}
+
+func (rss *RSS) FindArticle(substr string) (*Item, error) {
+	regex, err := regexp.Compile(strings.ToLower(substr))
+	if err != nil {
+		return nil, fmt.Errorf("Failed regex: %w", err)
+	}
+	for _, it := range rss.Channel.Items {
+		if regex.MatchString(strings.ToLower(it.Title)) {
+			return &it, nil
+		}
+	}
+	return nil, nil
 }
 
 func GlamouriseItem(item Item) (string, error) {

--- a/internal/rss/main.go
+++ b/internal/rss/main.go
@@ -3,8 +3,6 @@ package rss
 import (
 	"fmt"
 	"log"
-	"regexp"
-	"strings"
 	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
@@ -31,19 +29,6 @@ type Channel struct {
 
 type RSS struct {
 	Channel Channel `xml:"channel"`
-}
-
-func (rss *RSS) FindArticle(substr string) (*Item, error) {
-	regex, err := regexp.Compile(strings.ToLower(substr))
-	if err != nil {
-		return nil, fmt.Errorf("Failed regex: %w", err)
-	}
-	for _, it := range rss.Channel.Items {
-		if regex.MatchString(strings.ToLower(it.Title)) {
-			return &it, nil
-		}
-	}
-	return nil, nil
 }
 
 func GlamouriseItem(item Item) (string, error) {


### PR DESCRIPTION
- Add option to view feed without loading feeds from a config (preview)
- [nom] Reverted some of the changes back, can now specify multiple feeds via --feed argument
- [nom] Removed option to specify feed to preview without flag
- [nom] Added in-memory cache for feeds preview
