### PR TITLE
fix: disable http2 client for requests

### DIFF
--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -62,6 +62,10 @@ func run(args []string, opts Options) error {
 }
 
 func main() {
+	// disable http2 client as causing issues with reddit rss feed requests
+	// https://github.com/guyfedwards/nom/issues/7
+	os.Setenv("GODEBUG", "http2client=0")
+
 	var opts Options
 
 	parser := flags.NewParser(&opts, flags.Default)


### PR DESCRIPTION
Setting the env var explicitly is the cleanest way to have all child
packages respect the client and keep it in the code rather than a build
flag.

closes #7