### PR TITLE
add feed names to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ or add directly to the config at `~/.config/nom/config.yml` on unix systems and 
 ```yaml
 feeds:
   - url: https://dropbox.tech/feed
+    # name will be prefixed to all entries in the list
+    name: dropbox 
   - url: https://snyk.io/blog/feed
 ```
 You can customise the location of the config file with the `--config-path` flag.

--- a/internal/commands/main.go
+++ b/internal/commands/main.go
@@ -109,7 +109,7 @@ func (c Commands) fetchAllFeeds(noCacheOverride bool) ([]rss.RSS, error) {
 		if c.config.NoCache || noCacheOverride || err == cache.ErrCacheMiss {
 			wg.Add(1)
 
-			go fetchFeed(ch, &wg, feed.URL)
+			go fetchFeed(ch, &wg, feed)
 		} else if err != nil {
 			log.Fatal("error getting cache")
 		} else {
@@ -143,17 +143,17 @@ func (c Commands) fetchAllFeeds(noCacheOverride bool) ([]rss.RSS, error) {
 	return rsss, nil
 }
 
-func fetchFeed(ch chan FetchResultError, wg *sync.WaitGroup, feedURL string) {
+func fetchFeed(ch chan FetchResultError, wg *sync.WaitGroup, feed config.Feed) {
 	defer wg.Done()
 
-	r, err := rss.Fetch(feedURL)
+	r, err := rss.Fetch(feed)
 
 	if err != nil {
-		ch <- FetchResultError{res: rss.RSS{}, err: err, url: feedURL}
+		ch <- FetchResultError{res: rss.RSS{}, err: err, url: feed.URL}
 		return
 	}
 
-	ch <- FetchResultError{res: r, err: nil, url: feedURL}
+	ch <- FetchResultError{res: r, err: nil, url: feed.URL}
 }
 
 func (c Commands) FindArticle(substr string) (item rss.Item, err error) {

--- a/internal/commands/tui.go
+++ b/internal/commands/tui.go
@@ -31,8 +31,9 @@ var (
 )
 
 type Item struct {
-	Title string
-	URL   string
+	Title    string
+	FeedName string
+	URL      string
 }
 
 func (i Item) FilterValue() string { return "" }
@@ -48,7 +49,12 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		return
 	}
 
-	str := fmt.Sprintf("%d. %s", index+1, i.Title)
+	var str string
+	if i.FeedName == "" {
+		str = fmt.Sprintf("%d. %s", index+1, i.Title)
+	} else {
+		str = fmt.Sprintf("%d. %s: %s", index+1, i.FeedName, i.Title)
+	}
 
 	fn := itemStyle.Render
 	if index == m.Index() {
@@ -189,8 +195,9 @@ func (m model) viewportHelp() string {
 
 func RSSToItem(c rss.Item) Item {
 	return Item{
-		Title: c.Title,
-		URL:   c.Link,
+		FeedName: c.FeedName,
+		Title:    c.Title,
+		URL:      c.Link,
 	}
 }
 

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Feed struct {
-	URL string `yaml:"url"`
+	URL  string `yaml:"url"`
+	Name string `yaml:"name,omitempty"`
 }
 
 type MinifluxBackend struct {
@@ -52,7 +53,7 @@ func New(configPath string, pager string, noCache bool, previewFeeds []string) (
 
 	var f []Feed
 	for _, feedURL := range previewFeeds {
-		f = append(f, Feed{feedURL})
+		f = append(f, Feed{URL: feedURL})
 	}
 
 	return Config{


### PR DESCRIPTION
allows adding of custom name to feeds in the config file. This will be
prefixed to the title in the end result.

<index>: [feedname]: <title>

Having it as a config option for each feed is more flexible and there
wasn't a consistent way to get it from the RSS feeds themselves
