### PR TITLE
fix: make module v2

### DIFF
--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/guyfedwards/nom/internal/commands"
-	"github.com/guyfedwards/nom/internal/config"
-	"github.com/guyfedwards/nom/internal/store"
+	"github.com/guyfedwards/nom/v2/internal/commands"
+	"github.com/guyfedwards/nom/v2/internal/config"
+	"github.com/guyfedwards/nom/v2/internal/store"
 )
 
 type Options struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/guyfedwards/nom
+module github.com/guyfedwards/nom/v2
 
 go 1.19
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -14,9 +14,9 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/glamour"
 
-	"github.com/guyfedwards/nom/internal/config"
-	"github.com/guyfedwards/nom/internal/rss"
-	"github.com/guyfedwards/nom/internal/store"
+	"github.com/guyfedwards/nom/v2/internal/config"
+	"github.com/guyfedwards/nom/v2/internal/rss"
+	"github.com/guyfedwards/nom/v2/internal/store"
 )
 
 type Commands struct {

--- a/internal/commands/tui.go
+++ b/internal/commands/tui.go
@@ -12,7 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
 
-	"github.com/guyfedwards/nom/internal/store"
+	"github.com/guyfedwards/nom/v2/internal/store"
 )
 
 var (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/guyfedwards/nom/internal/test"
+	"github.com/guyfedwards/nom/v2/internal/test"
 )
 
 const configFixturePath = "../test/data/config_fixture.yml"

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mmcdole/gofeed"
 
-	"github.com/guyfedwards/nom/internal/config"
+	"github.com/guyfedwards/nom/v2/internal/config"
 )
 
 type Item struct {

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/mmcdole/gofeed"
 
-	"github.com/guyfedwards/nom/internal/config"
+	"github.com/guyfedwards/nom/v2/internal/config"
 
-	"github.com/guyfedwards/nom/internal/test"
+	"github.com/guyfedwards/nom/v2/internal/test"
 )
 
 const dropboxFixture = "../test/data/dropbox_fixture.rss"


### PR DESCRIPTION
fixes issue with go install not pulling latest version and allows for bsd port

fixes #54, #51