### PR TITLE
New feature/add tag filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ $ nom list -n 20 # optionally show more
 $ nom add <feed_url> 
 $ nom --feed <feed_url> # preview feed without adding to config
 ```
+
+## Filtering
+Within the `nom` view, you can filter by title pressing the `/` character. If you'd like to filter by feed, just type your feed name using the following formats:
+```
+feed:my_feed
+feed:"my feed - with spaces"
+```
+
 ## Building and Running via Docker
 Build nom image
 ```sh


### PR DESCRIPTION
- Added Documentation bit for Filtering
- Override the `list.Filter` and `TUIItem.FilterValue`
- Make `enter` work as expected when working with `list` filter mode
- Added an extensible `Filterer` type to hold information related to filtering
- Added method `Filterer.GetItem` to extract the inferred `TUIItem` from what's returned by `TUIItem.FilterValue()`
- Added `Filterer.ExtractFiltersFor` method to pull tags that start with `tagname:` from search term
- Added `Filterer.FilterBy` method to actually pull ranks out based on filterValues and targetFilterValues passed in

If you have any criticism or concerns, please let me know, I'm happy to rework this as needed. I tried to make it easy to extend this for other filter values, and test based on my personal dataset, but I definitely didn't test everything possible.

I imagine if we want to, we could easily extend / move functionality for the boolean types like the `read` and new `favourite` attributes, just by tweaking the function to be something similar to `FilterByBool` or something.