### PR TITLE
chore: add nom gitignore, padding on app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .LSOverride
 ._*
 github_token
+nom

--- a/internal/commands/tui.go
+++ b/internal/commands/tui.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	appStyle               = lipgloss.NewStyle().Padding(0).Margin(0)
-	titleStyle             = list.DefaultStyles().Title.Margin(1, 0, 0, 0).Width(5)
+	appStyle               = lipgloss.NewStyle().Padding(1, 0, 0, 0).Margin(0)
+	titleStyle             = list.DefaultStyles().Title.Margin(0).Width(5)
 	itemStyle              = lipgloss.NewStyle().PaddingLeft(4)
 	selectedItemStyle      = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
 	readStyle              = lipgloss.NewStyle().PaddingLeft(4).Foreground(lipgloss.Color("240"))


### PR DESCRIPTION
moves padding to the app instead of title, stops the jumping around when changing modes e.g. showing the filter.