### PR TITLE
Fix the Dockerfile's environment for CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:alpine
 WORKDIR /app
-RUN apk add make 
+RUN apk add make alpine-sdk gcc
 COPY . .
+ENV CGO_ENABLED=1
 RUN make build
 CMD ["/app/nom", "--config-path", "docker-config.yml"]

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/glamour v0.7.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mmcdole/gofeed v1.1.3
 	github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f
 	golang.org/x/term v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZ
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/microcosm-cc/bluemonday v1.0.26 h1:xbqSvqzQMeEHCqMi64VAs4d8uy6Mequs3rQ0k/Khz58=
 github.com/microcosm-cc/bluemonday v1.0.26/go.mod h1:JyzOCs9gkyQyjs+6h10UEVSe02CGwkhd72Xdqh78TWs=
 github.com/mmcdole/gofeed v1.1.3 h1:pdrvMb18jMSLidGp8j0pLvc9IGziX4vbmvVqmLH6z8o=


### PR DESCRIPTION
I'm not sure if there were things that used to be done implicitly, or what exactly has prompted this issue, but I've found that a fresh build and run of the binary with Docker results in an environment that doesn't have `gcc` or `alpine-sdk` installed, and requires a couple build flags passed in, namely `CGO_ENABLED=1` and `CGO_CFLAGS="-D_LARGEFILE64_SOURCE"`. The last flag can be ignored if we update `go-sqlite3`, which seems like the right move.

All in all, I can say for sure that adding those packages and flags into the Dockerfile seems to solve all related issues completely. If you have any insights, please do let me know.

A slight alternative would be to continue with the update to sqlite3, but pass in CGO_ENABLED into the `Makefile`'s `build` section, but this seems more well-scoped to the issue at hand. Let me know if you'd like me to change that though.

Decided to open a PR as a form of discussion and potential solutions, rather than just an issue.

## Changes

```sh
go get -u github.com/mattn/go-sqlite3
```

Dockerfile:

```diff
FROM golang:alpine
WORKDIR /app
-RUN apk add make
+RUN apk add make alpine-sdk gcc
COPY . .
+ENV CGO_ENABLED=1
RUN make build
CMD ["/app/nom", "--config-path", "docker-config.yml"]
```