### PR TITLE
fix: crashing from opening links when a nil item is returned

### DIFF
--- a/internal/commands/tui.go
+++ b/internal/commands/tui.go
@@ -234,7 +234,13 @@ func updateList(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			if m.list.SettingFilter() {
 				break
 			}
-			current := m.list.SelectedItem().(TUIItem)
+
+			item := m.list.SelectedItem()
+			if item == nil {
+				return m, m.list.NewStatusMessage("No link selected.")
+			}
+
+			current := item.(TUIItem)
 			err := m.commands.OpenLink(current.URL)
 			if err != nil {
 				return m, tea.Quit


### PR DESCRIPTION
it now checks whether the returned item is nil and prints "No links selected."

How to recreate the issue:
add a RSS url so we would have bunch of articles in the main TUI.
then toggle read(m) all of them so no article would remain, then by clicking o to open links, the program would crash as a nil dereference and usage happens.