### PR TITLE
specify minimum tls version

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -179,7 +179,7 @@ func (c Commands) fetchAllFeeds() ([]store.Item, []ErrorItem, error) {
 	for _, feed := range feeds {
 		wg.Add(1)
 
-		go fetchFeed(ch, &wg, feed, c.config.Version)
+		go fetchFeed(ch, &wg, feed, c.config.HTTPOptions, c.config.Version)
 	}
 
 	go func() {

--- a/internal/commands/feeds.go
+++ b/internal/commands/feeds.go
@@ -96,10 +96,10 @@ func defaultView(items []store.Item) (is []store.Item) {
 	return is
 }
 
-func fetchFeed(ch chan FetchResultError, wg *sync.WaitGroup, feed config.Feed, version string) {
+func fetchFeed(ch chan FetchResultError, wg *sync.WaitGroup, feed config.Feed, httpOpts *config.HTTPOptions, version string) {
 	defer wg.Done()
 
-	r, err := rss.Fetch(feed, version)
+	r, err := rss.Fetch(feed, httpOpts, version)
 
 	if err != nil {
 		ch <- FetchResultError{res: rss.RSS{}, err: err, url: feed.URL}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,12 +49,6 @@ type Theme struct {
 	SelectedItemColor string `yaml:"selectedItemColor,omitempty"`
 }
 
-type HTTPOptions struct {
-	//MinTLSVersion must be set to one of the strings returned by
-	//tls.VersionName. "TLS 1.2" by default.
-	MinTLSVersion string `yaml:mintls,omitempty`
-}
-
 // need to add to Load() below if loading from config file
 type Config struct {
 	ConfigPath     string
@@ -150,6 +144,9 @@ func (c *Config) Load() error {
 	c.Openers = fileConfig.Openers
 
 	if fileConfig.HTTPOptions != nil {
+		if _, err := TLSVersion(fileConfig.HTTPOptions.MinTLSVersion); err != nil {
+			return err
+		}
 		c.HTTPOptions = fileConfig.HTTPOptions
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -48,6 +49,12 @@ type Theme struct {
 	SelectedItemColor string `yaml:"selectedItemColor,omitempty"`
 }
 
+type HTTPOptions struct {
+	//MinTLSVersion must be set to one of the strings returned by
+	//tls.VersionName. "TLS 1.2" by default.
+	MinTLSVersion string `yaml:mintls,omitempty`
+}
+
 // need to add to Load() below if loading from config file
 type Config struct {
 	ConfigPath     string
@@ -57,12 +64,13 @@ type Config struct {
 	Pager          string `yaml:"pager,omitempty"`
 	Feeds          []Feed `yaml:"feeds"`
 	// Preview feeds are distinguished from Feeds because we don't want to inadvertenly write those into the config file.
-	PreviewFeeds []Feed    `yaml:"previewfeeds,omitempty"`
-	Backends     *Backends `yaml:"backends,omitempty"`
-	ShowRead     bool      `yaml:"showread,omitempty"`
-	AutoRead     bool      `yaml:"autoread,omitempty"`
-	Openers      []Opener  `yaml:"openers,omitempty"`
-	Theme        Theme     `yaml:"theme,omitempty"`
+	PreviewFeeds []Feed       `yaml:"previewfeeds,omitempty"`
+	Backends     *Backends    `yaml:"backends,omitempty"`
+	ShowRead     bool         `yaml:"showread,omitempty"`
+	AutoRead     bool         `yaml:"autoread,omitempty"`
+	Openers      []Opener     `yaml:"openers,omitempty"`
+	Theme        Theme        `yaml:"theme,omitempty"`
+	HTTPOptions  *HTTPOptions `yaml:"http,omitempty"`
 }
 
 func (c *Config) ToggleShowRead() {
@@ -108,6 +116,9 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 			TitleColor:        "62",
 			FilterColor:       "62",
 		},
+		HTTPOptions: &HTTPOptions{
+			MinTLSVersion: tls.VersionName(tls.VersionTLS12),
+		},
 	}, nil
 }
 
@@ -137,6 +148,10 @@ func (c *Config) Load() error {
 	c.AutoRead = fileConfig.AutoRead
 	c.Feeds = fileConfig.Feeds
 	c.Openers = fileConfig.Openers
+
+	if fileConfig.HTTPOptions != nil {
+		c.HTTPOptions = fileConfig.HTTPOptions
+	}
 
 	if fileConfig.Theme.Glamour != "" {
 		c.Theme.Glamour = fileConfig.Theme.Glamour

--- a/internal/config/http.go
+++ b/internal/config/http.go
@@ -19,6 +19,8 @@ type HTTPOptions struct {
 	MinTLSVersion string `yaml:"mintls,omitempty"`
 }
 
+// TLSVersion maps one of a few supported TLS version strings to the corresponding
+// standard TLS library constant so that an HTTP client can be configured.
 func TLSVersion(configStr string) (uint16, error) {
 	if version, ok := tlsVersions[configStr]; ok {
 		return version, nil

--- a/internal/config/http.go
+++ b/internal/config/http.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// CloudFlare blocks requests unless a minimum TLSVersion is specified.
+var tlsVersions map[string]uint16 = map[string]uint16{
+	"TLS 1.0": tls.VersionTLS10,
+	"TLS 1.1": tls.VersionTLS11,
+	"TLS 1.2": tls.VersionTLS12,
+	"TLS 1.3": tls.VersionTLS13,
+}
+
+type HTTPOptions struct {
+	//MinTLSVersion must be set to one of the strings returned by
+	//tls.VersionName. "TLS 1.2" by default.
+	MinTLSVersion string `yaml:"mintls,omitempty"`
+}
+
+func TLSVersion(configStr string) (uint16, error) {
+	if version, ok := tlsVersions[configStr]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unsupported tls version: %s", configStr)
+}

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -1,7 +1,9 @@
 package rss
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -33,6 +35,16 @@ type RSS struct {
 
 func Fetch(f config.Feed, version string) (RSS, error) {
 	fp := gofeed.NewParser()
+
+	//CloudFlare blocks requests unless a minimum TLSVersion is specified.
+	fp.Client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS13,
+			},
+		},
+	}
+
 	fp.UserAgent = fmt.Sprintf("nom/%s", version)
 
 	feed, err := fp.ParseURL(f.URL)

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -33,16 +33,19 @@ type RSS struct {
 	Channel Channel `xml:"channel"`
 }
 
-func Fetch(f config.Feed, version string) (RSS, error) {
+func Fetch(f config.Feed, httpOpts *config.HTTPOptions, version string) (RSS, error) {
 	fp := gofeed.NewParser()
 
-	//CloudFlare blocks requests unless a minimum TLSVersion is specified.
-	fp.Client = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS13,
-			},
-		},
+	fp.Client = &http.Client{}
+
+	if httpOpts != nil {
+		if version, err := config.TLSVersion(httpOpts.MinTLSVersion); err == nil {
+			fp.Client.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: version,
+				},
+			}
+		}
 	}
 
 	fp.UserAgent = fmt.Sprintf("nom/%s", version)


### PR DESCRIPTION
I kept receiving 403s from https://fs.blog/feed/ . It turns out that it's probably because cloudflare blocks you unless you specify a minimum TLS version.

TLS 1.3 might be too high, but it solved my problem.