### PR TITLE
Add bold to Feed name on the item list

### DIFF
--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -47,7 +47,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	if i.FeedName == "" {
 		str = fmt.Sprintf("%3d. %s", index+1, i.Title)
 	} else {
-		str = fmt.Sprintf("%3d. %s: %s", index+1, i.FeedName, i.Title)
+		str = fmt.Sprintf("%3d. %s: %s", index+1, lipgloss.NewStyle().Bold(true).Render(i.FeedName), i.Title)
 	}
 
 	fn := itemStyle.Render


### PR DESCRIPTION
This way it's easier to know the feed name and the actual title. This is just a cosmetic change.

![image](https://github.com/user-attachments/assets/215405f2-4ef4-452b-94ae-804430778bd4)
