### PR TITLE
feat: refresh without tui interval functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ $ curl -L https://github.com/guyfedwards/nom/releases/download/v2.1.4/nom_2.1.4_
 ```sh
 $ nom # start TUI
 $ nom list -n 20 # list feed items in $PAGER, optionally show more
-$ nom add <feed_url> 
+$ nom add <feed_url>
+$ nom refresh # refresh feed(s) without opening TUI
+$ nom config # shows nom config
 $ nom --feed <feed_url> # preview feed without adding to config
 ```
 

--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -55,6 +55,10 @@ func run(args []string, opts Options) error {
 	switch args[0] {
 	case "list":
 		return cmds.List(opts.Number)
+	case "refresh":
+		return cmds.Refresh()
+	case "config":
+		return cmds.ShowConfig()
 	case "add":
 		if len(args) != 2 {
 			return ErrNotEnoughArgs

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -15,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
+	"gopkg.in/yaml.v3"
 
 	"github.com/guyfedwards/nom/v2/internal/config"
 	"github.com/guyfedwards/nom/v2/internal/rss"
@@ -147,6 +148,22 @@ func (c Commands) Add(url string) error {
 		return fmt.Errorf("commands Add: %w", err)
 	}
 
+	return nil
+}
+
+func (c Commands) Refresh() error {
+	_, _, err := c.fetchAllFeeds()
+	if err != nil {
+		return fmt.Errorf("commands Refresh: %w", err)
+	}
+	return nil
+}
+func (c Commands) ShowConfig() error {
+	yaml, err := yaml.Marshal(&c.config)
+	if err != nil {
+		return fmt.Errorf("commands Config: %w", err)
+	}
+	fmt.Print(string(yaml))
 	return nil
 }
 

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -124,11 +123,9 @@ func refreshList(m model) func() tea.Msg {
 
 		m.errors = es
 		// return tea.Batch(m.list.SetItems(convertItems(items)), m.list.NewStatusMessage("Refreshed."))
-		// get date in YYYY-MM-DD hh:mm:ss
-		now := time.Now().Format("2006-01-02 15:04:05")
 		return listUpdate{
 			items:  convertItems(items),
-			status: fmt.Sprintf("Refreshed at %s.", now),
+			status: "Refreshed.",
 		}
 	}
 }

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -123,9 +124,11 @@ func refreshList(m model) func() tea.Msg {
 
 		m.errors = es
 		// return tea.Batch(m.list.SetItems(convertItems(items)), m.list.NewStatusMessage("Refreshed."))
+		// get date in YYYY-MM-DD hh:mm:ss
+		now := time.Now().Format("2006-01-02 15:04:05")
 		return listUpdate{
 			items:  convertItems(items),
-			status: "Refreshed.",
+			status: fmt.Sprintf("Refreshed at %s.", now),
 		}
 	}
 }


### PR DESCRIPTION
Partial for #101

I couldn't wrap my head around on how to hook into TUI correctly to fetch but also dynamically update list like `r` key does but from some event or go routine.

- Added `config` for convenience.
- Added a timestamp for refreshed status.

If timestamp is welcomed I'm also open to making it configurable from config for those who prefer something other than `YYYY-MM-DD hh:mm:ss`.