### PR TITLE
feat: add sorting order to config and abiity to change order in TUI

### DIFF
--- a/internal/commands/feeds.go
+++ b/internal/commands/feeds.go
@@ -46,7 +46,7 @@ func (c Commands) GetAllFeeds() ([]store.Item, error) {
 		return []store.Item{}, fmt.Errorf("[commands.go] GetAllFeeds: %w", err)
 	}
 
-	is, err := c.store.GetAllItems(c.config.General.Ordering)
+	is, err := c.store.GetAllItems(c.config.Ordering)
 	if err != nil {
 		return []store.Item{}, fmt.Errorf("commands.go: GetAllFeeds %w", err)
 	}

--- a/internal/commands/feeds.go
+++ b/internal/commands/feeds.go
@@ -46,7 +46,7 @@ func (c Commands) GetAllFeeds() ([]store.Item, error) {
 		return []store.Item{}, fmt.Errorf("[commands.go] GetAllFeeds: %w", err)
 	}
 
-	is, err := c.store.GetAllItems()
+	is, err := c.store.GetAllItems(c.config.General.Ordering)
 	if err != nil {
 		return []store.Item{}, fmt.Errorf("commands.go: GetAllFeeds %w", err)
 	}

--- a/internal/commands/key.go
+++ b/internal/commands/key.go
@@ -16,6 +16,7 @@ type ListKeyMapT struct {
 	ToggleFavourites      key.Binding
 	Refresh               key.Binding
 	OpenInBrowser         key.Binding
+	Sort                  key.Binding
 	oQuit                 key.Binding
 	oForceQuit            key.Binding
 	oClearFilter          key.Binding
@@ -71,6 +72,10 @@ var ListKeyMap = ListKeyMapT{
 	OpenInBrowser: key.NewBinding(
 		key.WithKeys("o"),
 		key.WithHelp("o", "open in browser"),
+	),
+	Sort: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "sort"),
 	),
 	EditConfig: key.NewBinding(
 		key.WithKeys("E"),
@@ -166,7 +171,7 @@ func (k ViewportKeyMapT) ShortHelp() []key.Binding {
 func (k ListKeyMapT) FullHelp() []key.Binding {
 	return []key.Binding{
 		k.Open, k.Read, k.Favourite, k.Refresh,
-		k.OpenInBrowser, k.ToggleFavourites, k.ToggleReads,
+		k.OpenInBrowser, k.Sort, k.ToggleFavourites, k.ToggleReads,
 		k.MarkAllRead, k.EditConfig,
 	}
 }

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -91,6 +91,25 @@ func (m *model) UpdateList() tea.Cmd {
 	return cmd
 }
 
+func sortList(m model) func() tea.Msg {
+	return func() tea.Msg {
+		// reverse sorting order
+		if m.commands.config.General.Ordering == "asc" {
+			m.commands.config.General.Ordering = "desc"
+		} else {
+			m.commands.config.General.Ordering = "asc"
+		}
+
+		items, err := m.commands.GetAllFeeds()
+		if err != nil {
+			m.errors = []string{err.Error()}
+		}
+		return listUpdate{
+			items: convertItems(items),
+		}
+	}
+}
+
 func refreshList(m model) func() tea.Msg {
 	return func() tea.Msg {
 		var errorItems []ErrorItem
@@ -231,6 +250,17 @@ func updateList(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			current := item.(TUIItem)
 			cmd = m.commands.OpenLink(current.URL)
 			cmds = append(cmds, cmd)
+
+		case key.Matches(msg, ListKeyMap.Sort):
+			if m.list.SettingFilter() || m.list.IsFiltered() {
+				break
+			}
+
+			if len(m.list.Items()) == 0 {
+				return m, m.list.NewStatusMessage("No items to sort.")
+			}
+
+			cmds = append(cmds, sortList(m))
 
 		case key.Matches(msg, ListKeyMap.Open):
 			if m.list.SettingFilter() {

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/guyfedwards/nom/v2/internal/config"
+	"github.com/guyfedwards/nom/v2/internal/constants"
 	"github.com/guyfedwards/nom/v2/internal/store"
 )
 
@@ -94,10 +95,10 @@ func (m *model) UpdateList() tea.Cmd {
 func sortList(m model) func() tea.Msg {
 	return func() tea.Msg {
 		// reverse sorting order
-		if m.commands.config.General.Ordering == "asc" {
-			m.commands.config.General.Ordering = "desc"
+		if m.commands.config.Ordering == constants.AscendingOrdering {
+			m.commands.config.Ordering = constants.DescendingOrdering
 		} else {
-			m.commands.config.General.Ordering = "asc"
+			m.commands.config.Ordering = constants.AscendingOrdering
 		}
 
 		items, err := m.commands.GetAllFeeds()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/guyfedwards/nom/v2/internal/constants"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,6 +19,10 @@ var (
 type Feed struct {
 	URL  string `yaml:"url"`
 	Name string `yaml:"name,omitempty"`
+}
+
+type General struct {
+	Ordering string `yaml:"ordering"`
 }
 
 type MinifluxBackend struct {
@@ -54,9 +59,10 @@ type Config struct {
 	ConfigPath     string
 	ShowFavourites bool
 	Version        string
-	ConfigDir      string `yaml:"-"`
-	Pager          string `yaml:"pager,omitempty"`
-	Feeds          []Feed `yaml:"feeds"`
+	ConfigDir      string  `yaml:"-"`
+	Pager          string  `yaml:"pager,omitempty"`
+	Feeds          []Feed  `yaml:"feeds"`
+	General        General `yaml:"general"`
 	// Preview feeds are distinguished from Feeds because we don't want to inadvertenly write those into the config file.
 	PreviewFeeds []Feed       `yaml:"previewfeeds,omitempty"`
 	Backends     *Backends    `yaml:"backends,omitempty"`
@@ -110,6 +116,9 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 			TitleColor:        "62",
 			FilterColor:       "62",
 		},
+		General: General{
+			Ordering: constants.DefaultOrdering,
+		},
 		HTTPOptions: &HTTPOptions{
 			MinTLSVersion: tls.VersionName(tls.VersionTLS12),
 		},
@@ -148,6 +157,10 @@ func (c *Config) Load() error {
 			return err
 		}
 		c.HTTPOptions = fileConfig.HTTPOptions
+	}
+
+	if len(fileConfig.General.Ordering) > 0 {
+		c.General.Ordering = fileConfig.General.Ordering
 	}
 
 	if fileConfig.Theme.Glamour != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,10 +21,6 @@ type Feed struct {
 	Name string `yaml:"name,omitempty"`
 }
 
-type General struct {
-	Ordering string `yaml:"ordering"`
-}
-
 type MinifluxBackend struct {
 	Host   string `yaml:"host"`
 	APIKey string `yaml:"api_key"`
@@ -59,10 +55,10 @@ type Config struct {
 	ConfigPath     string
 	ShowFavourites bool
 	Version        string
-	ConfigDir      string  `yaml:"-"`
-	Pager          string  `yaml:"pager,omitempty"`
-	Feeds          []Feed  `yaml:"feeds"`
-	General        General `yaml:"general"`
+	ConfigDir      string `yaml:"-"`
+	Pager          string `yaml:"pager,omitempty"`
+	Feeds          []Feed `yaml:"feeds"`
+	Ordering       string `yaml:"ordering"`
 	// Preview feeds are distinguished from Feeds because we don't want to inadvertenly write those into the config file.
 	PreviewFeeds []Feed       `yaml:"previewfeeds,omitempty"`
 	Backends     *Backends    `yaml:"backends,omitempty"`
@@ -116,9 +112,7 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 			TitleColor:        "62",
 			FilterColor:       "62",
 		},
-		General: General{
-			Ordering: constants.DefaultOrdering,
-		},
+		Ordering: constants.DefaultOrdering,
 		HTTPOptions: &HTTPOptions{
 			MinTLSVersion: tls.VersionName(tls.VersionTLS12),
 		},
@@ -159,8 +153,8 @@ func (c *Config) Load() error {
 		c.HTTPOptions = fileConfig.HTTPOptions
 	}
 
-	if len(fileConfig.General.Ordering) > 0 {
-		c.General.Ordering = fileConfig.General.Ordering
+	if len(fileConfig.Ordering) > 0 {
+		c.Ordering = fileConfig.Ordering
 	}
 
 	if fileConfig.Theme.Glamour != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,7 +74,7 @@ func TestConfigLoad(t *testing.T) {
 		t.Fatalf("Parsing failed")
 	}
 
-	if len(c.General.Ordering) == 0 || c.General.Ordering != "desc" {
+	if len(c.Ordering) == 0 || c.Ordering != "desc" {
 		t.Fatalf("Parsing failed")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,10 @@ func TestConfigLoad(t *testing.T) {
 	if len(c.Feeds) != 3 || c.Feeds[0].URL != "cattle" {
 		t.Fatalf("Parsing failed")
 	}
+
+	if len(c.General.Ordering) == 0 || c.General.Ordering != "asc" {
+		t.Fatalf("Parsing failed")
+	}
 }
 
 func TestConfigLoadPrecidence(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,7 +74,7 @@ func TestConfigLoad(t *testing.T) {
 		t.Fatalf("Parsing failed")
 	}
 
-	if len(c.General.Ordering) == 0 || c.General.Ordering != "asc" {
+	if len(c.General.Ordering) == 0 || c.General.Ordering != "desc" {
 		t.Fatalf("Parsing failed")
 	}
 }

--- a/internal/constants/store.go
+++ b/internal/constants/store.go
@@ -1,0 +1,7 @@
+package constants
+
+// Store constants
+const (
+	DefaultOrdering    = "asc"
+	DescendingOrdering = "desc"
+)

--- a/internal/constants/store.go
+++ b/internal/constants/store.go
@@ -2,6 +2,7 @@ package constants
 
 // Store constants
 const (
-	DefaultOrdering    = "asc"
+	AscendingOrdering  = "asc"
 	DescendingOrdering = "desc"
+	DefaultOrdering    = AscendingOrdering
 )

--- a/internal/test/data/config_fixture.yml
+++ b/internal/test/data/config_fixture.yml
@@ -2,5 +2,4 @@ feeds:
   - url: cattle
   - url: bird
   - url: dog
-general:
-  ordering: desc
+ordering: desc

--- a/internal/test/data/config_fixture.yml
+++ b/internal/test/data/config_fixture.yml
@@ -2,3 +2,5 @@ feeds:
   - url: cattle
   - url: bird
   - url: dog
+general:
+  ordering: asc

--- a/internal/test/data/config_fixture.yml
+++ b/internal/test/data/config_fixture.yml
@@ -3,4 +3,4 @@ feeds:
   - url: bird
   - url: dog
 general:
-  ordering: asc
+  ordering: desc


### PR DESCRIPTION
Starting this as draft in case there's a different implementation approach desired for #74 and allowing me to self-review again at some point.

- Added `s` key for sorting in TUI on list view. Help is only on Full.
- Decided to use config for ordering and set default as `asc` to keep same behavior as "normal" scan. This could maybe use some discussion if order of items in table is a valid/desired sorting option?
- Left out sorting for preview feeds functionality.

Utilized store pointer to toggle sort and then reusing `GetAllFeeds` to apply other config like show favorites/read by default.