### PR TITLE
add: Filter feed names with fuzzy search

### DIFF
--- a/internal/commands/filter.go
+++ b/internal/commands/filter.go
@@ -19,23 +19,6 @@ type Filterer struct {
 	}
 }
 
-// Filters by specific filterValue/s on the Filterer.Term
-func (f *Filterer) FilterBy(filterValues []string, targetFilterValues []string, ranks []fuzzy.Match) []fuzzy.Match {
-	if filterValues != nil && len(filterValues) > 0 {
-		var filteredRanks []fuzzy.Match
-		for _, filterValue := range filterValues {
-			for _, rank := range ranks {
-				if strings.ToLower(targetFilterValues[rank.Index]) == filterValue {
-					filteredRanks = append(filteredRanks, rank)
-				}
-			}
-		}
-		return filteredRanks
-	}
-
-	return ranks
-}
-
 // Breaks what's returned from TUIItem.FilterValue() into a TUIItem.
 func (f *Filterer) GetItem(filterValue string) TUIItem {
 	var i TUIItem

--- a/internal/commands/filter.go
+++ b/internal/commands/filter.go
@@ -109,9 +109,14 @@ func (f *Filterer) Filter(targets []string) []fuzzy.Match {
 		targetFeedNames = append(targetFeedNames, i.FeedName)
 	}
 
-	ranks := fuzzy.Find(f.Term.Title, targetTitles)
-
-	ranks = f.FilterBy(f.FeedNames, targetFeedNames, ranks)
+	var ranks fuzzy.Matches
+	if len(f.FeedNames) == 0 {
+		ranks = fuzzy.Find(f.Term.Title, targetTitles)
+	} else {
+		for _, feedName := range f.FeedNames {
+			ranks = append(ranks, fuzzy.Find(feedName, targetFeedNames)...)
+		}
+	}
 
 	sort.Stable(ranks)
 


### PR DESCRIPTION
Resolves: https://github.com/guyfedwards/nom/issues/119

This PR implements fuzzy searching on tags.

I removed the old `FilterBy` function and introduced a function to filter on the feed names. Also moved the condition of `FilterBy` outside of the function.

If a feed name matches multiple feed name filters in the fuzzy search, then only the best match will be returned. This is to prevent duplicates in the output.