### PR TITLE
feat: add name as a second param while adding feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ curl -L https://github.com/guyfedwards/nom/releases/download/v2.1.4/nom_2.1.4_
 ## Usage
 ```sh
 $ nom # start TUI
-$ nom add <feed_url>
+$ nom add <feed_url> <optional feed_name>
 $ nom -h # see all available command and options
 ```
 
@@ -37,7 +37,7 @@ feeds:
 ```
 You can also add feeds with the `add` command:
 ```sh
-$ nom add <url>
+$ nom add <url> <optional name>
 ```
 Feeds are editable within `nom` by pressing `E` to open the config in your `$EDITOR` or `$NOMEDITOR`. After editing feeds, you will need to then refresh with `r`.
 

--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -26,7 +26,8 @@ var (
 
 type Add struct {
 	Positional struct {
-		Url string `positional-arg-name:"URL" required:"yes"`
+		Url  string `positional-arg-name:"URL" required:"yes"`
+		Name string `positional-arg-name:"NAME" required:"no"`
 	} `positional-args:"yes"`
 }
 
@@ -35,7 +36,7 @@ func (r *Add) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	return cmds.Add(r.Positional.Url)
+	return cmds.Add(r.Positional.Url, r.Positional.Name)
 }
 
 type Config struct{}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -142,8 +142,8 @@ func (c Commands) List() error {
 	return outputToPager(output)
 }
 
-func (c Commands) Add(url string) error {
-	err := c.config.AddFeed(config.Feed{URL: url})
+func (c Commands) Add(url string, name string) error {
+	err := c.config.AddFeed(config.Feed{URL: url, Name: name})
 	if err != nil {
 		return fmt.Errorf("commands Add: %w", err)
 	}


### PR DESCRIPTION
I often add name after adding a feed, so desided to made it easier