### PR TITLE
feat: add freshrss.prefixCats

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ backends:
     host: http://myfreshrss.bar
     user: admin
     password: muchstrong
+    prefixCats: true # prefix feed name for freshrss entries
 ```
 
 #### FreshRSS

--- a/internal/config/backends.go
+++ b/internal/config/backends.go
@@ -32,8 +32,24 @@ type FreshRSSResponse struct {
 	Subscriptions []FreshRSSFeed `yaml:"subscriptions,omitempty"`
 }
 
+type Cat struct {
+	Label string `yaml:"label,omitempty"`
+}
+
 type FreshRSSFeed struct {
-	URL string `yaml:"url,omitempty"`
+	URL        string `yaml:"url,omitempty"`
+	Categories []Cat  `yaml:"categories,omitempty"`
+}
+
+func (frss FreshRSSFeed) GetCats() string {
+	ret := ""
+	for i, v := range frss.Categories {
+		if i != 0 {
+			ret += ","
+		}
+		ret += v.Label
+	}
+	return ret
 }
 
 func getFreshRSSFeeds(config *FreshRSSBackend) ([]Feed, error) {
@@ -82,7 +98,11 @@ func getFreshRSSFeeds(config *FreshRSSBackend) ([]Feed, error) {
 	var ret []Feed
 
 	for _, f := range b.Subscriptions {
-		ret = append(ret, Feed{URL: f.URL})
+		name := ""
+		if config.PrefixCats {
+			name = f.GetCats()
+		}
+		ret = append(ret, Feed{URL: f.URL, Name: name})
 	}
 
 	return ret, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,9 +28,10 @@ type MinifluxBackend struct {
 }
 
 type FreshRSSBackend struct {
-	Host     string `yaml:"host"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
+	Host       string `yaml:"host"`
+	User       string `yaml:"user"`
+	Password   string `yaml:"password"`
+	PrefixCats bool   `yaml:"prefixCats"`
 }
 
 type Backends struct {


### PR DESCRIPTION
prefixes the categories from freshrss to the beginning of the etnry same as name option in yaml

closes #92