### PR TITLE
feat: add refreshinterval for bg refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ filtering:
   defaultIncludeFeedName: true
 ```
 
+### Refresh interval
+Background refresh interval in minutes. Setting this to anything but 0 will make `nom` refresh automatically.
+```yaml
+refreshinterval: 5
+```
+
 
 ### Theme 
 Theme allows some basic color overrides in the feed view and then setting a custom markdown render theme for the overall markdown view. `theme.glamour` can be one of "dark", "dracula", "light", "pink", "ascii" or "notty". See [here](https://github.com/charmbracelet/glamour/tree/master/styles/gallery) for previews and more info.

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -166,10 +166,13 @@ func updateList(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case statusUpdate:
-		m.list.NewStatusMessage(msg.status)
+		cmds = append(cmds, m.list.NewStatusMessage(msg.status))
 	case listUpdate:
+		if m.list.SettingFilter() {
+			break
+		}
 		m.list.SetItems(msg.items)
-		m.list.NewStatusMessage(msg.status)
+		cmds = append(cmds, m.list.NewStatusMessage(msg.status))
 
 	case tea.ResumeMsg:
 		return m, nil

--- a/internal/commands/tui.go
+++ b/internal/commands/tui.go
@@ -216,14 +216,22 @@ func (c *Commands) TUI() error {
 		es = append(es, fmt.Sprintf("Error fetching %s: %s", e.FeedURL, e.Err))
 	}
 
-	if err := Render(items, c, es, c.config); err != nil {
+	prog, err := Render(items, c, es, c.config)
+
+	if err != nil {
 		return fmt.Errorf("commands.TUI: %w", err)
+	}
+
+	c.Monitor(prog)
+
+	if _, err := prog.Run(); err != nil {
+		return fmt.Errorf("tui.Render: %w", err)
 	}
 
 	return nil
 }
 
-func Render(items []list.Item, cmds *Commands, errors []string, cfg *config.Config) error {
+func Render(items []list.Item, cmds *Commands, errors []string, cfg *config.Config) (*tea.Program, error) {
 	const defaultWidth = 20
 	_, ts, _ := term.GetSize(int(os.Stdout.Fd()))
 	_, y := appStyle.GetFrameSize()
@@ -258,9 +266,7 @@ func Render(items []list.Item, cmds *Commands, errors []string, cfg *config.Conf
 		viewport: vp,
 	}
 
-	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
-		return fmt.Errorf("tui.Render: %w", err)
-	}
+	prog := tea.NewProgram(m, tea.WithAltScreen())
 
-	return nil
+	return prog, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,13 +70,14 @@ type Config struct {
 	Ordering       string       `yaml:"ordering"`
 	Filtering      FilterConfig `yaml:"filtering"`
 	// Preview feeds are distinguished from Feeds because we don't want to inadvertenly write those into the config file.
-	PreviewFeeds []Feed       `yaml:"previewfeeds,omitempty"`
-	Backends     *Backends    `yaml:"backends,omitempty"`
-	ShowRead     bool         `yaml:"showread,omitempty"`
-	AutoRead     bool         `yaml:"autoread,omitempty"`
-	Openers      []Opener     `yaml:"openers,omitempty"`
-	Theme        Theme        `yaml:"theme,omitempty"`
-	HTTPOptions  *HTTPOptions `yaml:"http,omitempty"`
+	PreviewFeeds    []Feed       `yaml:"previewfeeds,omitempty"`
+	Backends        *Backends    `yaml:"backends,omitempty"`
+	ShowRead        bool         `yaml:"showread,omitempty"`
+	AutoRead        bool         `yaml:"autoread,omitempty"`
+	Openers         []Opener     `yaml:"openers,omitempty"`
+	Theme           Theme        `yaml:"theme,omitempty"`
+	HTTPOptions     *HTTPOptions `yaml:"http,omitempty"`
+	RefreshInterval int          `yaml:"refreshinterval,omitempty"`
 }
 
 func (c *Config) ToggleShowRead() {
@@ -125,7 +126,8 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 			FilterColor:       "62",
 			ReadIcon:          "\u2713",
 		},
-		Ordering: constants.DefaultOrdering,
+		RefreshInterval: 0,
+		Ordering:        constants.DefaultOrdering,
 		Filtering: FilterConfig{
 			DefaultIncludeFeedName: false,
 		},
@@ -166,6 +168,7 @@ func (c *Config) Load() error {
 	c.Openers = fileConfig.Openers
 	c.ShowFavourites = fileConfig.ShowFavourites
 	c.Filtering = fileConfig.Filtering
+	c.RefreshInterval = fileConfig.RefreshInterval
 
 	if fileConfig.HTTPOptions != nil {
 		if _, err := TLSVersion(fileConfig.HTTPOptions.MinTLSVersion); err != nil {


### PR DESCRIPTION
add refreshinterval config option to set the background interval refresh in minutes calls fetchAllFeeds in background and sends a status message

close #101