### PR TITLE
feat: allow data store config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ openers:
 ## Store
 `nom` uses sqlite as a store for feeds and metadata. It is stored next to the config in `$XDG_CONFIG_HOME/nom/nom.db`. This can be backed up like any file and will store articles, read state etc. It can also be deleted to start from scratch redownloading all articles and no state.
 
+The name of the sqlite file can be overridden in the config file, allowing you to have multiple configs each with their own data store.
+
+```yaml
+database: news.db
+```
+
 ## Filtering
 Within the `nom` view, you can filter by title pressing the `/` character. Filters can be applied easily. Here's some examples:
 - `f:my_feed feed:my_second_feed` - matches `my_feed` and `my_second_feed`

--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -105,7 +105,7 @@ func getCmds() (*commands.Commands, error) {
 		return nil, err
 	}
 
-	s, err := store.NewSQLiteStore(cfg.ConfigDir)
+	s, err := store.NewSQLiteStore(cfg.ConfigDir, cfg.Database)
 	if err != nil {
 		return nil, fmt.Errorf("main.go: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	ConfigDir      string       `yaml:"-"`
 	Pager          string       `yaml:"pager,omitempty"`
 	Feeds          []Feed       `yaml:"feeds"`
+	Database       string       `yaml:"database"`
 	Ordering       string       `yaml:"ordering"`
 	Filtering      FilterConfig `yaml:"filtering"`
 	// Preview feeds are distinguished from Feeds because we don't want to inadvertenly write those into the config file.
@@ -113,6 +114,7 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 		ConfigPath:   configPath,
 		ConfigDir:    configDir,
 		Pager:        pager,
+		Database:	  "nom.db",
 		Feeds:        []Feed{},
 		PreviewFeeds: f,
 		Theme: Theme{
@@ -158,6 +160,7 @@ func (c *Config) Load() error {
 	c.ShowRead = fileConfig.ShowRead
 	c.AutoRead = fileConfig.AutoRead
 	c.Feeds = fileConfig.Feeds
+	c.Database = fileConfig.Database
 	c.Openers = fileConfig.Openers
 	c.ShowFavourites = fileConfig.ShowFavourites
 	c.Filtering = fileConfig.Filtering

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ func New(configPath string, pager string, previewFeeds []string, version string)
 		ConfigPath:   configPath,
 		ConfigDir:    configDir,
 		Pager:        pager,
-		Database:	  "nom.db",
+		Database:     "nom.db",
 		Feeds:        []Feed{},
 		PreviewFeeds: f,
 		Theme: Theme{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,7 +160,9 @@ func (c *Config) Load() error {
 	c.ShowRead = fileConfig.ShowRead
 	c.AutoRead = fileConfig.AutoRead
 	c.Feeds = fileConfig.Feeds
-	c.Database = fileConfig.Database
+	if fileConfig.Database != "" {
+		c.Database = fileConfig.Database
+	}
 	c.Openers = fileConfig.Openers
 	c.ShowFavourites = fileConfig.ShowFavourites
 	c.Filtering = fileConfig.Filtering

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,8 +49,8 @@ type SQLiteStore struct {
 	db   *sql.DB
 }
 
-func NewSQLiteStore(basePath string, dbname string) (*SQLiteStore, error) {
-	dbpath := filepath.Join(basePath, dbname)
+func NewSQLiteStore(basePath string, dbName string) (*SQLiteStore, error) {
+	dbpath := filepath.Join(basePath, dbName)
 
 	info, _ := os.Stat(dbpath)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,8 +49,8 @@ type SQLiteStore struct {
 	db   *sql.DB
 }
 
-func NewSQLiteStore(basePath string) (*SQLiteStore, error) {
-	dbpath := filepath.Join(basePath, "nom.db")
+func NewSQLiteStore(basePath string, dbname string) (*SQLiteStore, error) {
+	dbpath := filepath.Join(basePath, dbname)
 
 	info, _ := os.Stat(dbpath)
 


### PR DESCRIPTION
### Disclaimer

I have never touched go before and just took a stab at this change myself so as not to just be making requests for something I might be able to contribute instead. As it stands, the feature request outlined below is working as desired with this change, but if I overlooked some obvious extra things that needed to be included, now you know why. Either way, thanks for the nice software package.

### Reason for Change

When using multiple config files to be able to run nom under multiple 'profiles', of sorts, a user can separate different types of feeds effectively, but the hard-coded sqlite store file becomes a problem as each profile stomps over the others. There are various paths to solve this, but I figured the easiest solution would be to allow each alternate config file to define its own sqlite store to use.

The change submitted simply adds support for an optional `database` field in the config yml files to override the default `nom.db` filename.