### PR TITLE
fix: Correct .gitignore syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ dist/
 .LSOverride
 ._*
 github_token
-./nom
+/nom


### PR DESCRIPTION
To exclude a file at the root of a git repository, we need to write:

    /nom

Instead of:

    ./nom

This was causing the generated `nom` binary to show up as an untracked file
in the output of `git status`.
