### PR TITLE
fix: Fix config path handling

### DIFF
--- a/cmd/nom/main.go
+++ b/cmd/nom/main.go
@@ -14,7 +14,7 @@ import (
 type Options struct {
 	Verbose      bool     `short:"v" long:"verbose" description:"Show verbose logging"`
 	Pager        string   `short:"p" long:"pager" description:"Pager to use for longer output. Set to false for no pager"`
-	ConfigPath   string   `long:"config-path" description:"Location of config.yml"`
+	ConfigPath   string   `short:"c" long:"config-path" description:"Location of config.yml"`
 	PreviewFeeds []string `short:"f" long:"feed" description:"Feed(s) URL(s) for preview"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -89,22 +88,16 @@ func (c *Config) ToggleShowFavourites() {
 }
 
 func New(configPath string, pager string, previewFeeds []string, version string) (*Config, error) {
-	var configDir string
-
 	if configPath == "" {
 		userConfigDir, err := os.UserConfigDir()
 		if err != nil {
 			return nil, fmt.Errorf("config.New: %w", err)
 		}
 
-		configDir = filepath.Join(userConfigDir, "nom")
-		configPath = filepath.Join(configDir, "/config.yml")
-	} else {
-		// strip off end of path as config filename
-		sep := string(os.PathSeparator)
-		parts := strings.Split(configPath, sep)
-		configDir = strings.Join(parts[0:len(parts)-1], sep)
+		configPath = filepath.Join(userConfigDir, "nom", "config.yml")
 	}
+
+	configDir, _ := filepath.Split(configPath)
 
 	var f []Feed
 	for _, feedURL := range previewFeeds {
@@ -280,7 +273,7 @@ func (c *Config) GetFeeds() []Feed {
 }
 
 func setupConfigDir(configDir string) error {
-	configFile := filepath.Join(configDir, "/config.yml")
+	configFile := filepath.Join(configDir, "config.yml")
 
 	_, err := os.Stat(configFile)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,7 +25,7 @@ func TestNewDefault(t *testing.T) {
 	ucd, _ := os.UserConfigDir()
 
 	test.Equal(t, fmt.Sprintf("%s/nom/config.yml", ucd), c.ConfigPath, "Wrong defaults set")
-	test.Equal(t, fmt.Sprintf("%s/nom", ucd), c.ConfigDir, "Wrong default ConfigDir set")
+	test.Equal(t, fmt.Sprintf("%s/nom/", ucd), c.ConfigDir, "Wrong default ConfigDir set")
 }
 
 func TestConfigCustomPath(t *testing.T) {
@@ -37,7 +37,7 @@ func TestConfigCustomPath(t *testing.T) {
 func TestConfigDir(t *testing.T) {
 	c, _ := New("foo/bizzle/bar.yml", "", []string{}, "")
 
-	test.Equal(t, "foo/bizzle", c.ConfigDir, "ConfigDir not correctly parsed")
+	test.Equal(t, "foo/bizzle/", c.ConfigDir, "ConfigDir not correctly parsed")
 }
 
 func TestNewOverride(t *testing.T) {


### PR DESCRIPTION
The config handling code was erroneously including the path separator in arguments to `filepath.Join`, like this:

    configFile := filepath.Join(configDir, "/config.yml")

When running nom against a config file in the current directory:

    nom --config-path config.yml

This would result in `configDir` equal to `""`, and `configFile` would get set to `/config.yml`. This commit updates the path handling code to correctly use `filepath.Join`. It also replaces string splitting on paths with `filepath.Split`.

We also add a `-c` short option for setting the configuration path:

    nom -c config.yml