### PR TITLE
feat: Use GUID to identify articles in RSS feeds

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -244,6 +244,7 @@ func (c Commands) fetchAllFeeds() ([]store.Item, []ErrorItem, error) {
 				FeedURL:     result.url,
 				FeedName:    r.FeedName,
 				Link:        r.Link,
+				GUID:        r.GUID,
 				PublishedAt: r.PubDate,
 				Title:       r.Title,
 			}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -299,6 +299,7 @@ func updateList(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 
 				content, err := m.commands.GetGlamourisedArticle(*m.selectedArticle)
 				if err != nil {
+					// LKS: there should be an error message here
 					return m, tea.Quit
 				}
 

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -14,6 +14,7 @@ import (
 type Item struct {
 	Title       string    `xml:"title"`
 	Link        string    `xml:"link"`
+	GUID        string    `xml:"guid"`
 	Description string    `xml:"description"`
 	Author      string    `xml:"author"`
 	Categories  []string  `xml:"categories"`
@@ -70,6 +71,7 @@ func feedToRSS(f config.Feed, feed *gofeed.Feed) RSS {
 		ni := Item{
 			Title: it.Title,
 			Link:  it.Link,
+			GUID:  it.GUID,
 		}
 
 		if it.Description != "" {


### PR DESCRIPTION
Use Link rather than title to correlate feeds items with database items.
This permits us to correctly handle title changes without creating
duplicate entries.

Closes #167
