### PR TITLE
feat: add GitHub Action to build and push container to ghcr.io

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,47 @@
+name: container
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -280,6 +280,25 @@ Use the `-v` command line argument to mount a local configuration onto `/app/doc
 docker run --rm -it -v $PWD/my-nom-config.yml:/app/docker-config.yml nom
 ```
 
+## Running via pre-built container (ghcr.io)
+
+A container image is published to the GitHub Container Registry on every push to `master` and on each release tag.
+
+```sh
+docker run --rm -it ghcr.io/guyfedwards/nom:master
+```
+
+Mount your own config:
+
+```sh
+docker run --rm -it -v $PWD/my-nom-config.yml:/app/docker-config.yml ghcr.io/guyfedwards/nom:master
+```
+
+Available tags:
+- `master` - latest build from the main branch
+- `x.y.z` / `x.y` - pinned release versions (e.g. `3.0.0`)
+- `sha-<short-sha>` - exact commit builds
+
 ## Dev setup
 
 You can use `backends-compose.yml` to spin up a local instance of [MiniFlux] and [FreshRSS] if needed for development.


### PR DESCRIPTION
Adds a container workflow that builds and pushes to ghcr.io on pushes to master and on release tags. Updates README with instructions for running the pre-built image.